### PR TITLE
Drop redundant check of sqlite3 module availability

### DIFF
--- a/doc/source/configuration/configuring.rst
+++ b/doc/source/configuration/configuring.rst
@@ -1742,10 +1742,9 @@ One main configuration file option affects the image cache.
   be :ref:`migrated <sqlite-to-centralized_db-migration>` to
   central database on service restart during upgrade process.
 
-  The ``sqlite`` cache driver has no special dependencies, other
-  than the ``python-sqlite3`` library, which is installed on virtually
-  all operating systems with modern versions of Python. It stores
-  information about the cached files in a SQLite database.
+  The ``sqlite`` cache driver has no special dependencies, and uses
+  the built-in  ``sqlite3`` module. It stores information about the cached
+  files in a SQLite database.
 
   **NOTE**
   In Caracal release ``sqlite`` cache driver has been deprecated and will

--- a/glance/tests/unit/test_image_cache.py
+++ b/glance/tests/unit/test_image_cache.py
@@ -619,26 +619,8 @@ class TestImageCacheSqlite(test_utils.BaseTestCase,
     """Tests image caching when SQLite is used in cache"""
 
     def setUp(self):
-        """
-        Test to see if the pre-requisites for the image cache
-        are working (python-sqlite3 installed)
-        """
         super(TestImageCacheSqlite, self).setUp()
 
-        if getattr(self, 'disable', False):
-            return
-
-        if not getattr(self, 'inited', False):
-            try:
-                import sqlite3  # noqa
-            except ImportError:
-                self.inited = True
-                self.disabled = True
-                self.disabled_message = ("python-sqlite3 not installed.")
-                return
-
-        self.inited = True
-        self.disabled = False
         self.cache_dir = self.useFixture(fixtures.TempDir()).path
         self.config(image_cache_dir=self.cache_dir,
                     image_cache_driver='sqlite',


### PR DESCRIPTION
The sqlite3 module was merged into the core python in Python 2.5, and we can safely assume it is always available.

Change-Id: Ifdcb4567cb0e3f6d0e004fd52930c1f888a3f0fc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that the SQLite image cache driver uses Python’s built-in sqlite3 module, removing references to external dependencies.

* **Tests**
  * Simplified test setup for the SQLite image cache by removing checks for the sqlite3 module and related disabling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->